### PR TITLE
revisions for L0 and L0/BInf

### DIFF
--- a/src/ShiftedProximalOperators.jl
+++ b/src/ShiftedProximalOperators.jl
@@ -18,15 +18,19 @@ include("shiftedNormL1Binf.jl")
 include("shiftedIndBallL0.jl")
 include("shiftedIndBallL0BInf.jl")
 
-(ψ::ShiftedProximableFunction)(y) = ψ.h(ψ.x0 + ψ.x + y)
+(ψ::ShiftedProximableFunction)(y) = ψ.h(ψ.xk + ψ.sj + y)
 
 """
     shift!(ψ, x)
 
 Update the shift of a shifted proximable function.
 """
-function shift!(ψ::ShiftedProximableFunction, x::AbstractVector{R}) where {R <: Real}
-  ψ.x .= x
+function shift!(ψ::ShiftedProximableFunction, shift::AbstractVector{R}) where {R <: Real}
+  if ψ.shifted_twice
+    ψ.sj .= shift
+  else
+    ψ.xk .= shift
+  end
   return ψ
 end
 
@@ -52,8 +56,8 @@ end
 end
 
 fun_name(ψ::ShiftedProximableFunction) = "undefined"
-fun_expr(ψ::ShiftedProximableFunction) = "s ↦ h(x + s)"
-fun_params(ψ::ShiftedProximableFunction) = "x0 = $(ψ.x0)\n" * " "^14 * "x = $(ψ.x)"
+fun_expr(ψ::ShiftedProximableFunction) = "t ↦ h(xk + sj + t)"
+fun_params(ψ::ShiftedProximableFunction) = "xk = $(ψ.xk)\n" * " "^14 * "sj = $(ψ.sj)"
 
 function Base.show(io::IO, ψ::ShiftedProximableFunction)
   println(io, "description : ", fun_name(ψ))

--- a/src/shiftedIndBallL0.jl
+++ b/src/shiftedIndBallL0.jl
@@ -8,36 +8,38 @@ mutable struct ShiftedIndBallL0{
   V2 <: AbstractVector{R},
 } <: ShiftedProximableFunction
   h::IndBallL0{I}
-  x0::V0
-  x::V1
-  s::V2
+  xk::V0
+  sj::V1
+  sol::V2
   p::Vector{Int}
+  shifted_twice::Bool
 
   function ShiftedIndBallL0(
     h::IndBallL0{I},
-    x0::AbstractVector{R},
-    x::AbstractVector{R},
+    xk::AbstractVector{R},
+    sj::AbstractVector{R},
+    shifted_twice::Bool
   ) where {I <: Integer, R <: Real}
-    s = similar(x)
-    new{I, R, typeof(x0), typeof(x), typeof(s)}(h, x0, x, s, Vector{Int}(undef, length(x)))
+    sol = similar(sj)
+    new{I, R, typeof(xk), typeof(sj), typeof(sol)}(h, xk, sj, sol, Vector{Int}(undef, length(sj)), shifted_twice)
   end
 end
 
-shifted(h::IndBallL0{I}, x::AbstractVector{R}) where {I <: Integer, R <: Real} =
-  ShiftedIndBallL0(h, zero(x), x)
+shifted(h::IndBallL0{I}, xk::AbstractVector{R}) where {I <: Integer, R <: Real} =
+  ShiftedIndBallL0(h, xk, zero(xk), false)
 shifted(
   ψ::ShiftedIndBallL0{I, R, V0, V1, V2},
-  x::AbstractVector{R},
+  sj::AbstractVector{R},
 ) where {
   I <: Integer,
   R <: Real,
   V0 <: AbstractVector{R},
   V1 <: AbstractVector{R},
   V2 <: AbstractVector{R},
-} = ShiftedIndBallL0(ψ.h, ψ.x, x)
+} = ShiftedIndBallL0(ψ.h, ψ.xk, sj, true)
 
 fun_name(ψ::ShiftedIndBallL0) = "shifted L0 norm ball indicator"
-fun_expr(ψ::ShiftedIndBallL0) = "s ↦ χ({‖x + s‖₀ ≤ r})"
+fun_expr(ψ::ShiftedIndBallL0) = "t ↦ χ({‖xk + sj + t‖₀ ≤ r})"
 
 function prox(
   ψ::ShiftedIndBallL0{I, R, V0, V1, V2},
@@ -50,10 +52,10 @@ function prox(
   V1 <: AbstractVector{R},
   V2 <: AbstractVector{R},
 }
-  ψ.s .= ψ.x .+ ψ.x0 .+ q
+  ψ.sol .= ψ.xk .+ ψ.sj .+ q
   # find largest entries
-  sortperm!(ψ.p, ψ.s, rev = true, by = abs) # stock with ψ.p as placeholder
-  ψ.s[ψ.p[(ψ.h.r + 1):end]] .= 0 # set smallest to zero
-  ψ.s .-= ψ.x .+ ψ.x0
-  return ψ.s
+  sortperm!(ψ.p, ψ.sol, rev = true, by = abs) # stock with ψ.p as placeholder
+  ψ.sol[ψ.p[(ψ.h.r + 1):end]] .= 0 # set smallest to zero
+  ψ.sol .-= ψ.xk .+ ψ.sj
+  return ψ.sol
 end

--- a/src/shiftedNormL1.jl
+++ b/src/shiftedNormL1.jl
@@ -7,41 +7,43 @@ mutable struct ShiftedNormL1{
   V2 <: AbstractVector{R},
 } <: ShiftedProximableFunction
   h::NormL1{R}
-  x0::V0
-  x::V1
-  s::V2
+  xk::V0
+  sj::V1
+  sol::V2
+  shifted_twice::Bool
 
   function ShiftedNormL1(
     h::NormL1{R},
-    x0::AbstractVector{R},
-    x::AbstractVector{R},
+    xk::AbstractVector{R},
+    sj::AbstractVector{R},
+    shifted_twice::Bool,
   ) where {R <: Real}
-    s = similar(x)
-    new{R, typeof(x0), typeof(x), typeof(s)}(h, x0, x, s)
+    sol = similar(xk)
+    new{R, typeof(xk), typeof(sj), typeof(sol)}(h, xk, sj, sol, shifted_twice)
   end
 end
 
-shifted(h::NormL1{R}, x::AbstractVector{R}) where {R <: Real} = ShiftedNormL1(h, zero(x), x)
+shifted(h::NormL1{R}, xk::AbstractVector{R}) where {R <: Real} = ShiftedNormL1(h, xk, zero(xk), false)
 shifted(
   ψ::ShiftedNormL1{R, V0, V1, V2},
-  x::AbstractVector{R},
+  sj::AbstractVector{R},
 ) where {R <: Real, V0 <: AbstractVector{R}, V1 <: AbstractVector{R}, V2 <: AbstractVector{R}} =
-  ShiftedNormL1(ψ.h, ψ.x, x)
+  ShiftedNormL1(ψ.h, ψ.xk, sj, true)
 
 fun_name(ψ::ShiftedNormL1) = "shifted L1 norm"
-fun_expr(ψ::ShiftedNormL1) = "s ↦ ‖x + s‖₁"
-fun_params(ψ::ShiftedNormL1) = "x0 = $(ψ.x0)\n" * " "^14 * "x = $(ψ.x)"
+fun_expr(ψ::ShiftedNormL1) = "t ↦ ‖xk + sk + t‖₁"
+fun_params(ψ::ShiftedNormL1) = "xk = $(ψ.xk)\n" * " "^14 * "sj = $(ψ.sj)"
 
 function prox(
   ψ::ShiftedNormL1{R, V0, V1, V2},
   q::AbstractVector{R},
   σ::R,
 ) where {R <: Real, V0 <: AbstractVector{R}, V1 <: AbstractVector{R}, V2 <: AbstractVector{R}}
-  ψ.s .= -ψ.x .- ψ.x0
+  ψ.sol .= -ψ.xk .- ψ.sj
 
-  for i ∈ eachindex(ψ.s)
-    ψ.s[i] = min(max(ψ.s[i], q[i] - ψ.λ * σ), q[i] + ψ.λ * σ)
+  for i ∈ eachindex(ψ.sol)
+    ψ.sol[i] = min(max(ψ.sol[i], q[i] - ψ.λ * σ), q[i] + ψ.λ * σ)
   end
 
-  return ψ.s
+  return ψ.sol
 end


### PR DESCRIPTION
This fixes the NormL0 and NormL0BInf prox computations.

Will probably break other parts of the package, which will have to be fixed accordingly.
