### PR TITLE
rederived l1b2 for QR

### DIFF
--- a/src/shiftedNormL1B2.jl
+++ b/src/shiftedNormL1B2.jl
@@ -47,17 +47,15 @@ function prox(
   q::AbstractVector{R},
   σ::R,
 ) where {R <: Real, V0 <: AbstractVector{R}, V1 <: AbstractVector{R}, V2 <: AbstractVector{R}}
-  ProjB(y) = min.(max.(y, q .- ψ.λ * σ), q .+ ψ.λ * σ)
-  froot(η) = η - ψ.χ(ProjB((-ψ.sj - ψ.xk) .* (η / ψ.Δ)))
+  ProjB(y) = min.(max.(y, ψ.sj .+ q .- ψ.λ * σ), ψ.sj .+ q .+ ψ.λ * σ)
+  froot(η) = η - ψ.χ(ProjB((- ψ.xk) .* (η / ψ.Δ)))
 
-  ψ.sol .= ProjB(-ψ.sj - ψ.xk)
+  ψ.sol .= ProjB(- ψ.xk)
 
   if ψ.χ(ψ.sol) > ψ.Δ
     η = fzero(froot, 1e-10, Inf)
-    ψ.sol .*= (η / ψ.Δ)
+    ψ.sol .= ProjB((- ψ.xk) .* (η / ψ.Δ)) * (ψ.Δ / η)
   end
-  if ψ.χ(ψ.sol) > ψ.Δ
-    ψ.sol .*= (ψ.Δ / ψ.χ(ψ.sol))
-  end
+  ψ.sol .-= ψ.sj
   return ψ.sol
 end

--- a/src/shiftedNormL1B2.jl
+++ b/src/shiftedNormL1B2.jl
@@ -52,7 +52,7 @@ function prox(
 
   ψ.sol .= ProjB(- ψ.xk)
 
-  if ψ.χ(ψ.sol) > ψ.Δ
+  if ψ.Δ ≤ ψ.χ(ψ.sol)
     η = fzero(froot, 1e-10, Inf)
     ψ.sol .= ProjB((- ψ.xk) .* (η / ψ.Δ)) * (ψ.Δ / η)
   end

--- a/src/shiftedNormL1B2.jl
+++ b/src/shiftedNormL1B2.jl
@@ -53,7 +53,7 @@ function prox(
   ψ.sol .= ProjB(- ψ.xk)
 
   if ψ.Δ ≤ ψ.χ(ψ.sol)
-    η = fzero(froot, 1e-10, Inf)
+    η = find_zero(froot, ψ.Δ)
     ψ.sol .= ProjB((- ψ.xk) .* (η / ψ.Δ)) * (ψ.Δ / η)
   end
   ψ.sol .-= ψ.sj


### PR DESCRIPTION
Re-made the previous PR since it had changes from the l1-binf PR inside of it. 

Same deal: l1b2 works with QR + BPDN, but with QR+ODE we see NaN's from the root-finding algorithm.