### PR TITLE
Update Project.toml -- remove OpenBLAS32_jll dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,12 +6,10 @@ version = "0.1.0"
 [deps]
 libblastrampoline_jll = "8e850b90-86db-534c-a0d3-1478176c7d93"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-OpenBLAS32_jll = "656ef2d0-ae68-5445-9ca0-591084a874a2"
 ProximalOperators = "a725b495-10eb-56fe-b38b-717eba820537"
 Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
 
 [compat]
-OpenBLAS32_jll = "0.3.9"
 ProximalOperators = "0.15"
 Roots = "^1.0.0"
 julia = "^1.3.0"

--- a/src/ShiftedProximalOperators.jl
+++ b/src/ShiftedProximalOperators.jl
@@ -3,19 +3,8 @@ module ShiftedProximalOperators
 using LinearAlgebra
 
 using libblastrampoline_jll
-using OpenBLAS32_jll
 using ProximalOperators
 using Roots
-
-function __init__()
-  # Ensure LBT points to a valid BLAS for psvd()
-  if VERSION ≥ v"1.7"
-    config = LinearAlgebra.BLAS.lbt_get_config()
-    if !any(lib -> lib.interface == :lp64, config.loaded_libs)
-      LinearAlgebra.BLAS.lbt_forward(OpenBLAS32_jll.libopenblas_path)
-    end
-  end
-end
 
 export ShiftedProximableFunction
 export prox, prox!, set_radius!, shift!, shifted, set_bounds!


### PR DESCRIPTION
Julia already ships an ILP64 BLAS / LAPACK with `OpenBLAS_jll`.
We only need to load a LP64 for artifacts compiled with `Int32` integers such as MUMPS or Ipopt.