### PR TITLE
Add option to store the previous Jacobian in ShiftedComposite

### DIFF
--- a/src/ShiftedProximalOperators.jl
+++ b/src/ShiftedProximalOperators.jl
@@ -79,6 +79,7 @@ function shift!(ψ::ShiftedProximableFunction, shift::AbstractVector{R}) where {
 end
 
 function shift!(ψ::ShiftedCompositeProximableFunction, shift::AbstractVector{R}) where {R <: Real}
+  !isnothing(ψ.A_prev) && (ψ.A_prev.vals .= ψ.A.vals) # Update previous Jacobian if necessary
   ψ.c!(ψ.b, shift)
   ψ.J!(ψ.A, shift)
   return ψ

--- a/src/compositeNormL2.jl
+++ b/src/compositeNormL2.jl
@@ -2,7 +2,7 @@
 export CompositeNormL2
 
 @doc raw"""
-    CompositeNormL2(λ, c!, J!, A, b)
+    CompositeNormL2(λ, c!, J!, A, b; store_previous_jacobian::Bool = false)
 
 Returns function `c` composed with the `ℓ₂` norm:
 ```math
@@ -22,6 +22,8 @@ such that `J` is the Jacobian of `c`. It is expected that `m ≤ n`.
     c!(b <: AbstractVector{Real}, xk <: AbstractVector{Real})
     J!(A <: AbstractSparseMatrixCOO{Real, Integer}, xk <: AbstractVector{Real})
 ```
+Moreover, if you want shifted instances of the operator to store the previous Jacobian on each shift, you can specify `store_previous_jacobian = true`.
+This is particularly useful for quasi-Newton updates in the context of constrained optimization.
 """
 mutable struct CompositeNormL2{
   T <: Real,

--- a/src/compositeNormL2.jl
+++ b/src/compositeNormL2.jl
@@ -35,19 +35,21 @@ mutable struct CompositeNormL2{
   J!::F1
   A::M
   b::V
+  store_previous_jacobian::Bool
 
   function CompositeNormL2(
     λ::T,
     c!::Function,
     J!::Function,
     A::AbstractMatrix{T},
-    b::AbstractVector{T},
+    b::AbstractVector{T};
+    store_previous_jacobian::Bool = false
   ) where {T <: Real}
     λ > 0 || error("CompositeNormL2: λ should be positive")
     length(b) == size(A, 1) || error(
       "Composite Norm L2: Wrong input dimensions, the length of c(x) should be the same as the number of rows of J(x)",
     )
-    new{T, typeof(c!), typeof(J!), typeof(A), typeof(b)}(NormL2(λ), c!, J!, A, b)
+    new{T, typeof(c!), typeof(J!), typeof(A), typeof(b)}(NormL2(λ), c!, J!, A, b, store_previous_jacobian)
   end
 end
 

--- a/src/shiftedCompositeNormL2.jl
+++ b/src/shiftedCompositeNormL2.jl
@@ -30,13 +30,14 @@ mutable struct ShiftedCompositeNormL2{
   F0 <: Function,
   F1 <: Function,
   M <: AbstractMatrix{T},
+  N <: Union{Nothing, M},
   V <: AbstractVector{T},
 } <: ShiftedCompositeProximableFunction
   h::NormL2{T}
   c!::F0
   J!::F1
   A::M
-  A_prev::Union{Nothing, M}  # (Optional) can be used to store the previous Jacobian, useful for quasi-Newton approximations
+  A_prev::N # (Optional) can be used to store the previous Jacobian, useful for quasi-Newton approximations
   shifted_spmat::qrm_shifted_spmat{T}
   spfct::qrm_spfct{T}
   b::V
@@ -71,7 +72,7 @@ mutable struct ShiftedCompositeNormL2{
     shifted_spmat = qrm_shift_spmat(spmat)
     spfct = qrm_spfct_init(spmat)
 
-    new{T, typeof(c!), typeof(J!), typeof(A), typeof(b)}(
+    new{T, typeof(c!), typeof(J!), typeof(A), typeof(A_prev), typeof(b)}(
       NormL2(λ),
       c!,
       J!,
@@ -113,13 +114,13 @@ fun_params(ψ::ShiftedCompositeNormL2) = "c(xk) = $(ψ.b)\n" * " "^14 * "J(xk) =
 
 function prox!(
   y::AbstractVector{T},
-  ψ::ShiftedCompositeNormL2{T, F0, F1, M, V},
+  ψ::ShiftedCompositeNormL2{T, F0, F1, M, N, V},
   q::AbstractVector{T},
   ν::T;
   max_iter = 10,
   atol = eps(T)^0.3,
   max_time = 180.0,
-) where {T <: Real, F0 <: Function, F1 <: Function, M <: AbstractMatrix{T}, V <: AbstractVector{T}}
+) where {T <: Real, F0 <: Function, F1 <: Function, M <: AbstractMatrix{T}, N <: Union{Nothing, M}, V <: AbstractVector{T}}
   @assert ν > zero(T)
   start_time = time()
   θ = T(0.8)

--- a/src/shiftedCompositeNormL2.jl
+++ b/src/shiftedCompositeNormL2.jl
@@ -1,6 +1,6 @@
 export ShiftedCompositeNormL2
 @doc raw"""
-    ShiftedCompositeNormL2(h, c!, J!, A, b)
+    ShiftedCompositeNormL2(h, c!, J!, A, b; store_previous_jacobian::Bool = false)
 
 Returns the shift of a function `c` composed with the `ℓ₂` norm (see CompositeNormL2.jl).
 Here, `c` is linearized i.e, `c(x + s) ≈ c(x) + J(x)s`. 
@@ -21,6 +21,9 @@ such that `J` is the Jacobian of `c`. It is expected that `m ≤ n`.
 c!(b <: AbstractVector{Real}, xk <: AbstractVector{Real})
 J!(A <: AbstractSparseMatrixCOO{Real, Integer}, xk <: AbstractVector{Real})
 ```
+Moreover, if you want shifted instances of the operator to store the previous Jacobian on each shift, you can specify `store_previous_jacobian = true`.
+In this case, each time a shift is performed, the previous Jacobian is stored in the `A_prev` field.
+This is particularly useful for quasi-Newton updates in the context of constrained optimization.
 """
 mutable struct ShiftedCompositeNormL2{
   T <: Real,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -89,6 +89,12 @@ for (op, composite_op, shifted_op) ∈
     @test all(ϕ_store_prev.A_prev .== SparseMatrixCOO([4.0 0.0 0.0 -1.0; 0.0 1.0 1.0 0.0]))
     @test all(ϕ_store_prev.A .== SparseMatrixCOO([8.0 0.0 0.0 -1.0; 0.0 1.0 1.0 0.0]))
 
+    # test reshifting
+    xk = [0.5, 0.0, 0.0, 0.0]
+    shift!(ϕ_store_prev, xk)
+    @test all(ϕ_store_prev.A_prev .== SparseMatrixCOO([8.0 0.0 0.0 -1.0; 0.0 1.0 1.0 0.0]))
+    @test all(ϕ_store_prev.A .== SparseMatrixCOO([2.0 0.0 0.0 -1.0; 0.0 1.0 1.0 0.0]))
+
 
     # test different types
     h = Op(Float32(λ))


### PR DESCRIPTION
@dpo,

This is useful when i make quasi-Newton updates for the Hessian of the Lagrangian (eq 18.13 in Nocedal & Wright).
Additionnally, I add full row rankness of the Jacobian as a struct field.

I used this code a few months ago for the different benchmarks in the SIOPT paper.

I will need a bump to a new version afterwards.