### PR TITLE
Fix allocations test errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         version:
           - 'lts'
           - '1'
-          - 'nightly'
+          - 'pre'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ libblastrampoline_jll = "8e850b90-86db-534c-a0d3-1478176c7d93"
 
 [compat]
 ProximalOperators = "0.15"
-QRMumps = "^0.3.0"
+QRMumps = "^0.3.2"
 Roots = "^1.0.0"
 SparseMatricesCOO = "0.2"
 julia = "^1.10.0"

--- a/test/test_allocs.jl
+++ b/test/test_allocs.jl
@@ -29,6 +29,7 @@ macro wrappedallocs(expr)
   argnames = [gensym() for a in expr.args]
   quote
     function g($(argnames...))
+      $(Expr(expr.head, argnames...))
       @allocated $(Expr(expr.head, argnames...))
     end
     $(Expr(:call, :g, [esc(a) for a in expr.args]...))

--- a/test/test_allocs.jl
+++ b/test/test_allocs.jl
@@ -72,12 +72,12 @@ end
     ψ = shifted(h, xk)
     y = rand(n)
     val = ψ(y)
-    allocs = @allocated ψ(y)
+    allocs = @wrappedallocs ψ(y)
     @test allocs == 0
 
     ψ = shifted(h, xk, -3.0, 4.0, rand(1:n, Int(n / 2)))
     val = ψ(y)
-    allocs = @allocated ψ(y)
+    allocs = @wrappedallocs ψ(y)
     @test allocs == 0
   end
 
@@ -88,13 +88,13 @@ end
     ψ = shifted(h, xk)
     y = rand(n)
     val = ψ(y)
-    allocs = @allocated ψ(y)
+    allocs = @wrappedallocs ψ(y)
     @test allocs == 0
 
     χ = NormLinf(1.0)
     ψ = shifted(h, xk, 0.5, χ)
     val = ψ(y)
-    allocs = @allocated ψ(y)
+    allocs = @wrappedallocs ψ(y)
     @test allocs == 0
   end
 

--- a/test/test_allocs.jl
+++ b/test/test_allocs.jl
@@ -73,12 +73,12 @@ end
     y = rand(n)
     val = ψ(y)
     allocs = @allocated ψ(y)
-    @test allocs == 16
+    @test allocs == 0
 
     ψ = shifted(h, xk, -3.0, 4.0, rand(1:n, Int(n / 2)))
     val = ψ(y)
     allocs = @allocated ψ(y)
-    @test allocs == 16
+    @test allocs == 0
   end
 
   for op ∈ (:IndBallL0,)
@@ -89,13 +89,13 @@ end
     y = rand(n)
     val = ψ(y)
     allocs = @allocated ψ(y)
-    @test allocs == 16
+    @test allocs == 0
 
     χ = NormLinf(1.0)
     ψ = shifted(h, xk, 0.5, χ)
     val = ψ(y)
     allocs = @allocated ψ(y)
-    @test allocs == 16
+    @test allocs == 0
   end
 
   for op ∈ (:NormL0, :NormL1)


### PR DESCRIPTION
closes #145 

See [#145 (comment)](https://github.com/JuliaSmoothOptimizers/ShiftedProximalOperators.jl/issues/145#issuecomment-3608602201).

I guess that test will fail on lts with this but we should try to make 0 allocations on lts and not the other way around.